### PR TITLE
MOT changes + Res Change

### DIFF
--- a/common/abilities/reservation_abilities.txt
+++ b/common/abilities/reservation_abilities.txt
@@ -1,0 +1,52 @@
+ability = {
+	use_deathray = {
+		name = ABILITY_USE_NELLIE
+		desc = ABILITY_USE_NELLIE_DESC
+
+		sound_effect = use_fatman_sound
+
+		type = army_leader
+		cost = 0.10
+		allowed = {
+			NOT = { has_trait = exhausted_order_trait}
+			is_leading_army_group = no
+			OWNER = {
+				has_country_flag = res_nellie_id
+				NOT = { has_idea = res_nellie_id_cooldown }
+			}
+		}
+		duration = 200
+
+		one_time_effect = {
+			add_timed_unit_leader_trait = {
+				trait = exhausted_order_trait
+				days = 20
+			}
+			add_temporary_buff_to_units = {
+				combat_offense = 0.15
+				combat_breakthrough = 0.15
+				org_damage_multiplier = -0.20
+				days = 7
+				tooltip = ABILITY_FORCE_ATTACK_TOOLTIP
+			}
+			OWNER = {
+				add_timed_idea = {
+					idea = res_nellie_id_cooldown
+					days = 60
+				}
+			}
+		}
+		ai_will_do = {
+			factor = -1
+			modifier = {
+				check_variable = { num_units_defensive_combats > 6 }
+
+				set_temp_variable = { temp = avg_defensive_combat_status }
+				check_variable = { temp < 0.40 }
+				check_variable = { ai_random > temp }
+
+				add = 2
+			}
+		}
+	}
+}

--- a/common/dynamic_modifiers/ncr_legion_dynamic_modifiers.txt
+++ b/common/dynamic_modifiers/ncr_legion_dynamic_modifiers.txt
@@ -1,0 +1,8 @@
+mojave_state_modifier = {
+	enable = { always = yes }
+	icon = GFX_modifiers_FIN_motti_tactics_modifier
+	local_supplies_for_controller = 0.1
+	army_speed_factor_for_controller = 0.05
+	army_speed_factor = -0.2
+	enemy_army_speed_factor = -0.05
+}

--- a/common/dynamic_modifiers/ncr_legion_dynamic_modifiers.txt
+++ b/common/dynamic_modifiers/ncr_legion_dynamic_modifiers.txt
@@ -2,7 +2,8 @@ mojave_state_modifier = {
 	enable = { always = yes }
 	icon = GFX_modifiers_FIN_motti_tactics_modifier
 	local_supplies_for_controller = 0.1
-	army_speed_factor_for_controller = 0.05
-	army_speed_factor = -0.2
-	enemy_army_speed_factor = -0.05
+	army_speed_factor_for_controller = 0.1
+	army_speed_factor = -0.1
+	enemy_army_speed_factor = -0.2
+	army_core_defence_factor = 0.05
 }

--- a/common/ideas/zzz_RES_ideas.txt
+++ b/common/ideas/zzz_RES_ideas.txt
@@ -3,6 +3,14 @@
 
 ideas = {
 	country = {
+		res_nellie_id_cooldown = {
+			picture = generic_nuclear_aftermath
+			removal_cost = -1
+			modifier = {
+				fuel_gain_factor = -0.25
+				industrial_capacity_factory = -0.1
+			}
+		}
 		res_sub_level_2_idea = {
 			picture = generic_production_bonus
 			removal_cost = -1

--- a/common/ideas/zzz_legion_ideas.txt
+++ b/common/ideas/zzz_legion_ideas.txt
@@ -15,6 +15,21 @@ ideas = {
 		}
 	}
 	country = {
+		ces_dam_win_idea = {
+			removal_cost = -1
+			allowed = {
+				always = no
+			}
+			allowed_civil_war = {
+				always = yes
+			}
+			picture = pre-war_industry
+			modifier = {
+				political_power_factor = 0.05
+				production_factory_max_efficiency_factor = 0.05
+				industrial_capacity_factory = 0.05
+			}
+		}
 		ces_victory_in_the_east = {
 			removal_cost = -1
 			allowed = {

--- a/common/national_focus/Mojave Territories (MOT) Focus.txt
+++ b/common/national_focus/Mojave Territories (MOT) Focus.txt
@@ -1540,6 +1540,18 @@ focus_tree = {
 		}
 		completion_reward = {
 			custom_effect_tooltip = mot_victory_at_the_dam_tt
+			#hidden_effect = {
+				every_state = {
+					limit = {
+						is_owned_by = ROOT
+						NOT = { state = 252 }
+						NOT = { impassable = yes }
+					}
+					add_dynamic_modifier = {
+						modifier = mojave_state_modifier
+					}
+				}
+			#}
 		}
 	}
 
@@ -1942,7 +1954,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = mot_first_supply_shipment
 		completion_reward = {
-			add_stability = -0.1
+			add_stability = 0.05
 			custom_effect_tooltip = mot_review_bittersprings_tt
 			country_event = { id = nf_mot.28 }
 		}
@@ -2263,6 +2275,7 @@ focus_tree = {
 				tooltip = mot_gov_op_small_down
 			}
 			hidden_effect = {
+				retire_country_leader = yes
 				add_country_leader_role = {
 					character = MOT_josh_hanlon
 					promote_leader = yes
@@ -2277,7 +2290,6 @@ focus_tree = {
 						id = -1
 					}
 				}
-				retire_country_leader = yes
 				set_character_name = {
 					character = MOT_josh_hanlon
 					name = MOT_JOSH_HANLON_LEADER_NAME
@@ -2552,7 +2564,7 @@ focus_tree = {
 			focus = mot_promote_chief_hanlon
 		}
 		prerequisite = {
-			focus = mot_first_supply_shipment
+			focus = mot_review_bittersprings
 		}
 		x = -3
 		y = 1

--- a/common/national_focus/Mojave Territories (MOT) Focus.txt
+++ b/common/national_focus/Mojave Territories (MOT) Focus.txt
@@ -1543,7 +1543,10 @@ focus_tree = {
 			#hidden_effect = {
 				every_state = {
 					limit = {
-						is_owned_by = ROOT
+						OR = {
+							is_owned_by = MOT
+							is_owned_by = VEG
+						}
 						NOT = { state = 252 }
 						NOT = { impassable = yes }
 					}

--- a/common/national_focus/The Reservation (RES) Focus.txt
+++ b/common/national_focus/The Reservation (RES) Focus.txt
@@ -706,9 +706,11 @@ focus_tree = {
 			focus = res_elite
 		}
 		completion_reward = {
-			set_technology = { artillery_ammo_unlock_tech = 1 }
-			custom_effect_tooltip = res_added_nuke_tt
-			country_event = nf_events_green_res.1
+			set_country_flag = res_nellie_id
+			custom_effect_tooltip = res_nuke_ability_tt
+			#set_technology = { artillery_ammo_unlock_tech = 1 }
+			#custom_effect_tooltip = res_added_nuke_tt
+			#country_event = nf_events_green_res.1
 		}
 	}
 	focus = {
@@ -1251,31 +1253,28 @@ focus_tree = {
             RES_add_workshops = yes
         }
     }
-    focus = {
-        id = resg_ultimate_deterent
-        icon = GFX_goal_RES_Red_Button
-        cost = 30
-        x = 0
-        y = 1
-        available = {
-        	always = no
-        }
-        prerequisite = {
-            focus = resg_expand_production
-        }
-        relative_position_id = resg_expand_production
-        completion_reward = {
-            custom_effect_tooltip = res_armed_nuke_green_tt
-            hidden_effect = {
-                # Setup nellie target states
-                add_to_array = { res_nellie_targets_array = 4.id }	# Ocotillo/Tanditown
-                add_to_array = { res_nellie_targets_array = 252.id }	# Hoover Dam
-                add_to_array = { res_nellie_targets_array = 211.id }	# New Vegas
-                add_to_array = { res_nellie_targets_array = 99.id }	# Tumblehome/Pharmville and Blythe
-            }
-        }
-    }
-
+    #focus = {
+    #    id = resg_ultimate_deterent
+    #    icon = GFX_goal_RES_Red_Button
+    #    cost = 30
+    #    x = 0
+    #    y = 1
+    #    prerequisite = {
+    #        focus = resg_expand_production
+    #    }
+    #    relative_position_id = resg_expand_production
+    #    completion_reward = {
+    #        custom_effect_tooltip = res_armed_nuke_green_tt
+    #        hidden_effect = {
+    #            # Setup nellie target states
+    #            add_to_array = { res_nellie_targets_array = 4.id }	# Ocotillo/Tanditown
+    #            add_to_array = { res_nellie_targets_array = 252.id }	# Hoover Dam
+    #            add_to_array = { res_nellie_targets_array = 211.id }	# New Vegas
+    #            add_to_array = { res_nellie_targets_array = 99.id }	# Tumblehome/Pharmville and Blythe
+    #        }
+    #    }
+    #}
+	#
     # army with a state spirit
     focus = {
         id = resg_army_with_spirit

--- a/common/scripted_effects/hoover_dam_scripted_effects.txt
+++ b/common/scripted_effects/hoover_dam_scripted_effects.txt
@@ -202,47 +202,9 @@ fbhd_bw_boulder = { # Script to start the initial border war for Boulder City
 
 fbhd_legion_overall_vic = {
 	clr_global_flag = first_battle_ongoing
-	set_global_flag = fbhd_legion_overall_vic
-	every_state = {
-		limit = {
-			OR = {
-				state = 252
-				state = 613
-				state = 380
-				state = 573
-				state = 46
-				state = 417
-				state = 137
-				state = 67
-				state = 106
-				state = 620
-			}
-			is_owned_and_controlled_by = MOT
-		}
-		CES = { transfer_state = PREV }
-	}
+	set_global_flag = fbhd_boulder_city_miracle_flag
 	MOT = {
-		every_unit_leader = {
-			set_nationality = NCR
-		}
-		every_navy_leader = {
-			set_nationality = NCR
-		}
-		every_owned_state = {
-			set_state_flag = do_not_decimate
-		}
-	}
-	NCR = {
-		change_tag_from = MOT
-	}
-	NCR = {
-		annex_country = {
-			target = MOT
-			transfer_troops = yes
-		}
-		every_owned_state = {
-			clr_state_flag = do_not_decimate
-		}
+		transfer_state = 252 # Hoover Dam
 	}
 	news_event = bhd.17
 }

--- a/events/hoover_dam_events.txt
+++ b/events/hoover_dam_events.txt
@@ -333,23 +333,17 @@ news_event = { # News Event: Legion Overall Vic
 
 	major = yes
 	is_triggered_only = yes
-
+	
 	option = {
 		trigger = {
 			is_new_california_member = yes
 		}
-		name = bhd.17.a
+		name = bhd.18.a
 		if = {
 			limit = {
-				NOT = {
-					NCR = {
-						has_completed_focus = ncr_lost_not_forgotten
-					}
-				}
+				TAG =  MOT
 			}
-			NCR = {
-				complete_national_focus = ncr_lost_not_forgotten
-			}
+			MOT = { complete_national_focus = mot_victory_at_the_dam }
 		}
 	}
 
@@ -361,9 +355,14 @@ news_event = { # News Event: Legion Overall Vic
 			limit = {
 				original_tag = CES
 			}
-			complete_national_focus = ces_this_was_a_triumph
+			complete_national_focus = ces_ncr_won_dam
+			add_timed_idea = {
+				idea = ces_dam_win_idea
+				days = 730
+			}
+			army_experience = 50 
 		}
-		name = bhd.17.b
+		name = bhd.18.b
 	}
 
 	option = {
@@ -371,7 +370,7 @@ news_event = { # News Event: Legion Overall Vic
 			NOT = { is_new_california_member = yes }
 			NOT = { is_caesars_legion_member = yes }
 		}
-		name = bhd.17.c
+		name = bhd.18.c
 	}
 }
 

--- a/localisation/english/RES/abilities_RES_l_english.yml
+++ b/localisation/english/RES/abilities_RES_l_english.yml
@@ -5,3 +5,4 @@
   ABILITY_USE_NELLIE:0 "Nuclear Nelly"
   ABILITY_USE_NELLIE_DESC:0 "A pre-war Railway cannon capable of mounting nuclear warheads. The lethality of such a weapon is unmatched in the post-war world. It can only be used sporadically but packs a punch like none other."
   ces_dam_win_idea:0 "Legion Victory at Dam"
+  mojave_state_modifier:0 "Mojave State"

--- a/localisation/english/RES/abilities_RES_l_english.yml
+++ b/localisation/english/RES/abilities_RES_l_english.yml
@@ -1,0 +1,7 @@
+﻿l_english:
+  res_nuke_ability_tt:0 "§PNuclear Nelly§! will become available as a §GCommand Ability§!.\nAfter being used it needs to recharge for §R60 Days§!"
+  res_nellie_id_cooldown:0 "Nellie Reloading"
+  res_nellie_id_cooldown_desc:0 "The sub-level workers are busy reloading the Nuclear Nelly. This will take up a lot of our resources for a while."
+  ABILITY_USE_NELLIE:0 "Nuclear Nelly"
+  ABILITY_USE_NELLIE_DESC:0 "A pre-war Railway cannon capable of mounting nuclear warheads. The lethality of such a weapon is unmatched in the post-war world. It can only be used sporadically but packs a punch like none other."
+  ces_dam_win_idea:0 "Legion Victory at Dam"

--- a/map/adjacencies.csv
+++ b/map/adjacencies.csv
@@ -66,21 +66,6 @@ From;To;Type;Through;start_x;start_y;stop_x;stop_y;adjacency_rule_name;Comment
 6314;3529;impassable;-1;-1;-1;-1;-1;;Ruby Valley to Pale Folk
 6313;3529;impassable;-1;-1;-1;-1;-1;;Ruby Valley to Pale Folk
 ;;;;;;;;;
-972;3210;impassable;-1;-1;-1;-1;-1;;Inner Mojave Ring
-972;3207;impassable;-1;-1;-1;-1;-1;;Inner Mojave Ring
-972;3204;impassable;-1;-1;-1;-1;-1;;Inner Mojave Ring
-6996;3204;impassable;-1;-1;-1;-1;-1;;Inner Mojave Ring
-6996;3206;impassable;-1;-1;-1;-1;-1;;Inner Mojave Ring
-6996;5760;impassable;-1;-1;-1;-1;-1;;Inner Mojave Ring
-6996;3226;impassable;-1;-1;-1;-1;-1;;Inner Mojave Ring
-3202;3226;impassable;-1;-1;-1;-1;-1;;Inner Mojave Ring
-6990;3226;impassable;-1;-1;-1;-1;-1;;Inner Mojave Ring
-6990;3228;impassable;-1;-1;-1;-1;-1;;Inner Mojave Ring
-3235;9067;impassable;-1;-1;-1;-1;-1;;Inner Mojave Ring
-3235;9068;impassable;-1;-1;-1;-1;-1;;Inner Mojave Ring
-3235;9072;impassable;-1;-1;-1;-1;-1;;Inner Mojave Ring
-3235;5766;impassable;-1;-1;-1;-1;-1;;Inner Mojave Ring
-;;;;;;;;;
 7305;12532;impassable;-1;-1;-1;-1;-1;;Northwest Plaguelands Wall
 7305;12546;impassable;-1;-1;-1;-1;-1;;Northwest Plaguelands Wall
 7305;3821;impassable;-1;-1;-1;-1;-1;;Northwest Plaguelands Wall


### PR DESCRIPTION
Mojave Territories Hanlon Path Fixed: (Bitter Springs cant be bypassed and is less punishing, Hanlon actually becomes Leader)
Hoover Dam Battle no longer kills MOT. It will buff Legion for 2 years but force them down the "Dam defeat" path as if they lost
After Hoover Dam the MOT add a state modifier to every state in the Mojave reducing speed of divisions (especially enemy divisions) Hoover dam does not get this modifier. Also local supplies for controller and core defense for controller is increased.
The impassable terrain around Mojave Chapter is removed.
The Reservation now no longer gets Artillery or Nuclear Strikes.
They get a new commander ability with a 60 Day Cooldown instead.
