### PR TITLE
MoT change and River Crossings

### DIFF
--- a/common/dynamic_modifiers/ncr_legion_dynamic_modifiers.txt
+++ b/common/dynamic_modifiers/ncr_legion_dynamic_modifiers.txt
@@ -2,8 +2,15 @@ mojave_state_modifier = {
 	enable = { always = yes }
 	icon = GFX_modifiers_FIN_motti_tactics_modifier
 	local_supplies_for_controller = 0.1
-	army_speed_factor_for_controller = 0.1
-	army_speed_factor = -0.1
-	enemy_army_speed_factor = -0.2
+	army_speed_factor = -0.2
+	enemy_army_speed_factor = -0.3
+	army_core_defence_factor = 0.05
+}
+hoover_state_modifier = {
+	enable = { always = yes }
+	icon = GFX_modifiers_SOV_armored_battery
+	local_supplies_for_controller = 0.15
+	enemy_army_speed_factor = -0.3
+	army_core_attack_factor = 0.05
 	army_core_defence_factor = 0.05
 }

--- a/map/adjacencies.csv
+++ b/map/adjacencies.csv
@@ -387,6 +387,7 @@ From;To;Type;Through;start_x;start_y;stop_x;stop_y;adjacency_rule_name;Comment
 7691;7650;sea;5825;-1;-1;-1;-1;;Baudelio Ranchers to Sinaloa
 7662;7650;sea;5825;-1;-1;-1;-1;;Baudelio Ranchers to Sinaloa
 ;;;;;;;;;
+4652;4671;sea;;-1;-1;-1;-1;;Baja Crossing
 4659;4661;sea;;-1;-1;-1;-1;;Baja Crossing
 ;;;;;;;;;
 8928;5792;sea;3057;-1;-1;-1;-1;;Gila Mouth Crossing
@@ -683,11 +684,21 @@ From;To;Type;Through;start_x;start_y;stop_x;stop_y;adjacency_rule_name;Comment
 3107;2047;sea;3057;-1;-1;-1;-1;;NCRvLegion Crossing
 5314;2047;sea;3057;-1;-1;-1;-1;;NCRvLegion Crossing
 ;;;;;;;;;
+4651;4671;sea;535;-1;-1;-1;-1;;NCRvLegion Crossing
+4654;4671;sea;535;-1;-1;-1;-1;;NCRvLegion Crossing
+7562;4671;sea;535;-1;-1;-1;-1;;NCRvLegion Crossing
+7561;4671;sea;535;-1;-1;-1;-1;;NCRvLegion Crossing
+2189;4671;sea;535;-1;-1;-1;-1;;NCRvLegion Crossing
+7549;4671;sea;535;-1;-1;-1;-1;;NCRvLegion Crossing
+7547;4671;sea;535;-1;-1;-1;-1;;NCRvLegion Crossing
+4668;7547;sea;535;-1;-1;-1;-1;;NCRvLegion Crossing
+;;;;;;;;;
 5807;8929;sea;3057;-1;-1;-1;-1;;NCRvLegion Crossing
 5807;3273;sea;3059;-1;-1;-1;-1;;NCRvLegion Crossing
 5807;5149;sea;3059;-1;-1;-1;-1;;NCRvLegion Crossing
 5640;3272;sea;3059;-1;-1;-1;-1;;NCRvLegion Crossing
 5640;5149;sea;3059;-1;-1;-1;-1;;NCRvLegion Crossing
+
 ;;;;;;;;;
 2317;1679;sea;3060;-1;-1;-1;-1;;NCRvLegion Crossing
 2317;1678;sea;3060;-1;-1;-1;-1;;NCRvLegion Crossing


### PR DESCRIPTION
River Crossings in Baja are restored to what they were last week
The state modifier slowing units in the mojave has been changed:
was:	
	army_speed_factor_for_controller = 0.1
	army_speed_factor = -0.1
	enemy_army_speed_factor = -0.2
	army_core_defence_factor = 0.05
Is now:	
	army_speed_factor = -0.2
	enemy_army_speed_factor = -0.3
	army_core_defence_factor = 0.05

Oliver now gets the following state modifier only on Hoover Dam after completing the "Reinforce Hoover Dam" focus:
        enemy_army_speed_factor = -0.3
	army_core_attack_factor = 0.05
	army_core_defence_factor = 0.05